### PR TITLE
Support AWS session tokens

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,6 +16,7 @@ module.exports.pad = function(n) {
 AWS.config.update({
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    sessionToken: process.env.AWS_SESSION_TOKEN,
     region: process.env.AWS_DEFAULT_REGION || 'us-east-1'
 });
 module.exports.s3 = new AWS.S3;


### PR DESCRIPTION
Fixes a bug where a session token could be required and be present and just not passed to the sdk.
